### PR TITLE
fix: actually build for openssl

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,10 +1,8 @@
 @echo on
 set "PYO3_PYTHON=%PYTHON%"
 
-set MATURIN_SETUP_ARGS=--no-default-features --features=native-tls
-
 set "CMAKE_GENERATOR=NMake Makefiles"
-maturin build -v --jobs 1 --release --strip --manylinux off --interpreter=%PYTHON%
+maturin build -v --jobs 1 --release --strip --manylinux off --interpreter=%PYTHON% --no-default-features --features=native-tls
 if errorlevel 1 exit 1
 
 FOR /F "delims=" %%i IN ('dir /s /b target\wheels\*.whl') DO set py_rattler_wheel=%%i

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -6,7 +6,7 @@ echo rustc --version
 export OPENSSL_DIR=$PREFIX
 
 # Use native-tls on conda-forge
-export MATURIN_SETUP_ARGS="--no-default-features --features=native-tls"
+export MATURIN_PEP517_ARGS="--no-default-features --features=native-tls"
 
 # Run the maturin build via pip which works for direct and
 # cross-compiled builds.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 67d48c1745aa43b4df95c8fab0dd4ffcdd5d9e15014ac4af4994dc5ec1b887b8
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: py-rattler


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

https://github.com/conda/rattler/issues/961 reported that it seems that py-rattler isnt properly using openssl. And indeed if you look at the build output it also shows that we are overdepending on openssl which seems odd. I think we were using the wrong flag to tell maturin to use a different feature set than the default one. This PR hopefully corrects that.

Fixes https://github.com/conda/rattler/issues/961