### PR TITLE
Add linux-ppc64le support

### DIFF
--- a/.ci_support/linux_ppc64le_is_python_mintruepython3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_is_python_mintruepython3.10.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+is_abi3:
+- true
+is_python_min:
+- true
+openssl:
+- '3.5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+python_min:
+- '3.10'
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - python
+  - is_python_min

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -40,6 +40,15 @@ jobs:
             tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+          - CONFIG: linux_ppc64le_is_python_mintruepython3.10.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
     steps:
 
     - name: Checkout code

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,7 @@
 bot:
   automerge: version
+build_platform:
+  linux_ppc64le: linux_64
 conda_build:
   error_overlinking: true
 conda_build_tool: rattler-build
@@ -13,3 +15,4 @@ provider:
   osx_64: default
   osx_arm64: default
   linux_aarch64: default
+  linux_ppc64le: default

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "2026.5.29"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/py-rattler-feedstock"
 authors = ["@conda-forge/py-rattler"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
+platforms = ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-64", "osx-arm64", "win-64"]
 requires-pixi = ">=0.59.0"
 
 [dependencies]
@@ -35,6 +35,12 @@ description = "Build py-rattler-feedstock with variant linux_aarch64_is_python_m
 [tasks."inspect-linux_aarch64_is_python_mintruepython3.10.____cpython"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_is_python_mintruepython3.10.____cpython.yaml"
 description = "List contents of py-rattler-feedstock packages built for variant linux_aarch64_is_python_mintruepython3.10.____cpython"
+[tasks."build-linux_ppc64le_is_python_mintruepython3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_is_python_mintruepython3.10.____cpython.yaml"
+description = "Build py-rattler-feedstock with variant linux_ppc64le_is_python_mintruepython3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_is_python_mintruepython3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_is_python_mintruepython3.10.____cpython.yaml"
+description = "List contents of py-rattler-feedstock packages built for variant linux_ppc64le_is_python_mintruepython3.10.____cpython"
 [tasks."build-osx_64_is_python_mintruepython3.10.____cpython"]
 cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_is_python_mintruepython3.10.____cpython.yaml"
 description = "Build py-rattler-feedstock with variant osx_64_is_python_mintruepython3.10.____cpython directly (without setup scripts)"

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -11,6 +11,15 @@ export CARGO="cargo-auditable-wrapper"
 
 export OPENSSL_DIR=$PREFIX
 
+# rust-lld (LLD) cannot handle some of the relocations GCC emits for ppc64le
+# (e.g. inline-PLT R_PPC64_PLTSEQ/PLTCALL), which breaks linking of C-based
+# crates such as aws-lc-sys and libdbus-sys. Fall back to the GNU bfd linker on
+# that platform, which handles these relocations. gcc honors the last
+# -fuse-ld, so this overrides rustc's bundled rust-lld default.
+if [[ "${target_platform}" == "linux-ppc64le" ]]; then
+  export CARGO_BUILD_RUSTFLAGS="${CARGO_BUILD_RUSTFLAGS:-} -C link-arg=-fuse-ld=bfd"
+fi
+
 # Use native-tls on conda-forge
 export MATURIN_PEP517_ARGS="--no-default-features --features=native-tls"
 


### PR DESCRIPTION
Enable the linux_ppc64le platform by adding it to the provider section
of conda-forge.yml and re-rendering with conda-smithy.

Fixed #87 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
